### PR TITLE
Improve error handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -91,7 +91,7 @@ async function sendMessageToActiveTab(message) {
 		return await browser.tabs.sendMessage(activeTab.id, message);
 	}
 	catch (e) {
-		console.error("Sending message to active tab failed, you might need to refresh the page after updating the extension.", e);
+		throw e;
 	}
 }
 

--- a/bin/release-chrome.sh
+++ b/bin/release-chrome.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 VERSION=$(jq -r ".version" manifest.json)
 CHROME_EXTENSION_ID=dfhgmnfclbebfobmblelddiejjcijbjm

--- a/bin/release-firefox.sh
+++ b/bin/release-firefox.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 WEB_EXT_ID="{1410742d-b377-40e7-a9db-63dc9c6ec99c}"
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export GITHUB_REPO=trilium-web-clipper
 


### PR DESCRIPTION
I found that attempting to screenshot pages that the extension doesn't have access to (about: pages in Firefox, chrome:// pages in Chrome) will create a blank note with a broken image, and report no feedback to this happening. It isn't much, but this pushes the error up to the page, and the try-catch runs now to show the general failure alert.

Also, I updated the release scripts to add `set -e` so it will exit immediately upon a command failure.