### PR TITLE
Keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Trilium Web Clipper
+Trilium Web Clipper is a web browser extension which allows user to clip text, screenshots, whole pages and short notes and save them directly to [Trilium Notes](https://github.com/zadam/trilium). 
 
-See details on [wiki page](https://github.com/zadam/trilium/wiki/Web-clipper).
+For more details, see the [wiki page](https://github.com/zadam/trilium/wiki/Web-clipper).
 
-Some parts of the code are based on the [Joplin Notes](https://github.com/laurent22/joplin/tree/master/Clipper).
+## Keyboard shortcuts
+Keyboard shortcuts are available for most functions:  
+* Save selected text: `Ctrl+Shift+S` (Mac: `Cmd+Shift+S`)
+* Save whole page: `Alt+Shift+S` (Mac: `Opt+Shift+S`)
+* Save screenshot: `Ctrl+Shift+E` (Mac: `Cmd+Shift+E`)
+
+To set custom shortcuts, follow the directions for your browser.
+
+**Firefox**: `about:addons` > Gear icon ⚙️ > Manage extension shortcuts
+
+**Chrome**: `chrome://extensions/shortcuts`
+
+## Credits
+Some parts of the code are based on the [Joplin Notes browser extension](https://github.com/laurent22/joplin/tree/master/Clipper).

--- a/background.js
+++ b/background.js
@@ -1,3 +1,18 @@
+// Keyboard shortcuts
+chrome.commands.onCommand.addListener(async function (command) {
+    if(command=="saveSelection") {
+        await saveSelection();
+    } else if (command == "saveWholePage") {
+        await saveWholePage();
+    } else if (command == "saveScreenshot") {
+        const activeTab = await getActiveTab();
+        await saveScreenshot(activeTab);
+    } else {
+        console.log("Unrecognized command", command);
+    }
+
+});
+
 function cropImage(newArea, dataUrl) {
 	return new Promise((resolve, reject) => {
 		const img = new Image();

--- a/manifest.json
+++ b/manifest.json
@@ -47,6 +47,26 @@
   "options_ui": {
     "page": "options/options.html"
   },
+  "commands": {
+    "saveSelection": {
+      "description": "Save the selected text into a note",
+      "suggested_key": {
+        "default": "Ctrl+Shift+S"
+      }
+    },
+    "saveWholePage": {
+      "description": "Save the current page",
+      "suggested_key": {
+        "default": "Alt+Shift+S"
+      }
+    },
+    "saveScreenshot": {
+      "description": "Take a screenshot of the current page",
+      "suggested_key": {
+        "default": "Ctrl+Shift+E"
+      }
+    }
+  },
   "browser_specific_settings": {
     "gecko": {
       "id": "{1410742d-b377-40e7-a9db-63dc9c6ec99c}"


### PR DESCRIPTION
This adds basic support for keyboard shortcuts to the extension. Some additional considerations:

- **Choice of default keys**: I picked ones that worked for me, but would be good to get feedback from others on whether these are sensible defaults. I've tested them in FF and Chrome on Mac, but _have not_ confirmed that the defaults work on Windows/Linux (I think they should, though!)
- **Documentation**: I added a small section to the readme about how shortcuts work. This can be added/moved to the wiki page after release. Do you prefer if all documentation stays within the wiki to keep a single source of truth?
- **Customization & extension UI**: Wow, keyboard shortcut support [is a mess](https://stackoverflow.com/a/45348255)! TL;DR: Firefox can update shortcuts programmatically but Chrome can't, and they each expose the shortcut customization page differently. We need a browser-dependent section of the options page, which is a bit more complicated so I haven't done this yet. So for now, shortcuts are invisible to users unless they read the documentation, which is not ideal.

Any feedback is appreciated! 