### PR TITLE
Add send current window's tabs feature

### DIFF
--- a/background.js
+++ b/background.js
@@ -251,50 +251,6 @@ async function saveWholePage() {
 	toast("Page has been saved to Trilium.", resp.noteId);
 }
 
-async function getTabsPayload(tabs) {
-	let content = '<ul>';
-	tabs.forEach(tab => {
-		content += `<li><a href="${tab.url}">${tab.title}</a></li>`
-	});
-	content += '</ul>';
-
-	// topDomains string with 1-3 most used domains will be used as the note title
-	// to help the user differentiate between multiple notes of this type
-	const domainsCount = tabs.map(tab => tab.url)
-		.reduce((acc, url) => {
-			const hostname = new URL(url).hostname
-			return acc.set(hostname, (acc.get(hostname) || 0) + 1)
-		}, new Map());
-
-	let topDomains = [...domainsCount]
-		.sort((a, b) => {return b[1]-a[1]})
-		.slice(0,3)
-		.map(domain=>domain[0])
-		.join(', ')
-
-	if (tabs.length > 3) { topDomains += '...' };
-
-	return {
-                title: `${tabs.length} browser tabs: ${topDomains}`,
-                content: content,
-                clipType: 'tabs'
-	};
-}
-
-async function saveTabs() {
-        const tabs = await getWindowTabs();
-
-	const payload = await getTabsPayload(tabs);
-
-	const resp = await triliumServerFacade.callService('POST', 'notes', payload);
-
-	if (!resp) {
-		return;
-	}
-
-	await closeWindowTabs(tabs);
-}
-
 async function saveNote(title, content) {
 	const resp = await triliumServerFacade.callService('POST', 'notes', {
 		title: title,
@@ -309,6 +265,48 @@ async function saveNote(title, content) {
 	toast("Note has been saved to Trilium.", resp.noteId);
 
 	return true;
+}
+
+async function getTabsPayload(tabs) {
+	let content = '<ul>';
+	tabs.forEach(tab => {
+		content += `<li><a href="${tab.url}">${tab.title}</a></li>`
+	});
+	content += '</ul>';
+
+	const domainsCount = tabs.map(tab => tab.url)
+		.reduce((acc, url) => {
+			const hostname = new URL(url).hostname
+			return acc.set(hostname, (acc.get(hostname) || 0) + 1)
+		}, new Map());
+
+	let topDomains = [...domainsCount]
+		.sort((a, b) => {return b[1]-a[1]})
+		.slice(0,3)
+		.map(domain=>domain[0])
+		.join(', ')
+
+	if (tabs.length > 3) { topDomains += '...' }
+
+	return {
+		title: `${tabs.length} browser tabs: ${topDomains}`,
+		content: content,
+		clipType: 'tabs'
+	};
+}
+
+async function saveTabs() {
+	const tabs = await getWindowTabs();
+
+	const payload = await getTabsPayload(tabs);
+
+	const resp = await triliumServerFacade.callService('POST', 'notes', payload);
+
+	if (!resp) {
+		return;
+	}
+
+	await closeWindowTabs(tabs);
 }
 
 browser.contextMenus.onClicked.addListener(async function(info, tab) {
@@ -388,11 +386,11 @@ browser.runtime.onMessage.addListener(async request => {
 	else if (request.name === 'save-whole-page') {
 		return await saveWholePage();
 	}
-	else if (request.name === 'save-tabs') {
-		return await saveTabs();
-	}
 	else if (request.name === 'save-note') {
 		return await saveNote(request.title, request.content);
+	}
+	else if (request.name === 'save-tabs') {
+		return await saveTabs();
 	}
 	else if (request.name === 'trigger-trilium-search') {
 		triliumServerFacade.triggerSearchForTrilium();

--- a/background.js
+++ b/background.js
@@ -4,6 +4,8 @@ chrome.commands.onCommand.addListener(async function (command) {
         await saveSelection();
     } else if (command == "saveWholePage") {
         await saveWholePage();
+    } else if (command == "saveTabs") {
+        await saveTabs();
     } else if (command == "saveScreenshot") {
         const activeTab = await getActiveTab();
 
@@ -98,6 +100,18 @@ async function getActiveTab() {
 	});
 
 	return tabs[0];
+}
+
+async function getWindowTabs() {
+	const tabs = await browser.tabs.query({
+		currentWindow: true
+	});
+
+	return tabs;
+}
+
+async function closeWindowTabs(tabs) {
+	await browser.tabs.remove(tabs.map(tab=>{return tab.id}));
 }
 
 async function sendMessageToActiveTab(message) {
@@ -237,6 +251,50 @@ async function saveWholePage() {
 	toast("Page has been saved to Trilium.", resp.noteId);
 }
 
+async function getTabsPayload(tabs) {
+	let content = '<ul>';
+	tabs.forEach(tab => {
+		content += `<li><a href="${tab.url}">${tab.title}</a></li>`
+	});
+	content += '</ul>';
+
+	// topDomains string with 1-3 most used domains will be used as the note title
+	// to help the user differentiate between multiple notes of this type
+	const domainsCount = tabs.map(tab => tab.url)
+		.reduce((acc, url) => {
+			const hostname = new URL(url).hostname
+			return acc.set(hostname, (acc.get(hostname) || 0) + 1)
+		}, new Map());
+
+	let topDomains = [...domainsCount]
+		.sort((a, b) => {return b[1]-a[1]})
+		.slice(0,3)
+		.map(domain=>domain[0])
+		.join(', ')
+
+	if (tabs.length > 3) { topDomains += '...' };
+
+	return {
+                title: `${tabs.length} browser tabs: ${topDomains}`,
+                content: content,
+                clipType: 'tabs'
+	};
+}
+
+async function saveTabs() {
+        const tabs = await getWindowTabs();
+
+	const payload = await getTabsPayload(tabs);
+
+	const resp = await triliumServerFacade.callService('POST', 'notes', payload);
+
+	if (!resp) {
+		return;
+	}
+
+	await closeWindowTabs(tabs);
+}
+
 async function saveNote(title, content) {
 	const resp = await triliumServerFacade.callService('POST', 'notes', {
 		title: title,
@@ -329,6 +387,9 @@ browser.runtime.onMessage.addListener(async request => {
 	}
 	else if (request.name === 'save-whole-page') {
 		return await saveWholePage();
+	}
+	else if (request.name === 'save-tabs') {
+		return await saveTabs();
 	}
 	else if (request.name === 'save-note') {
 		return await saveNote(request.title, request.content);

--- a/background.js
+++ b/background.js
@@ -110,10 +110,6 @@ async function getWindowTabs() {
 	return tabs;
 }
 
-async function closeWindowTabs(tabs) {
-	await browser.tabs.remove(tabs.map(tab=>{return tab.id}));
-}
-
 async function sendMessageToActiveTab(message) {
 	const activeTab = await getActiveTab();
 
@@ -306,7 +302,7 @@ async function saveTabs() {
 		return;
 	}
 
-	await closeWindowTabs(tabs);
+	toast(`${tabs.length} links have been saved to Trilium.`, resp.noteId);
 }
 
 browser.contextMenus.onClicked.addListener(async function(info, tab) {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -21,6 +21,7 @@
   <button class="button full needs-connection" id="clip-screenshot-button">Clip screenshot</button>
   <button class="button full needs-connection" id="save-whole-page-button">Save whole page</button>
   <button class="button full needs-connection" id="create-text-note-button">Create text note</button>
+  <button class="button full needs-connection" id="save-tabs-button">Save window's tabs as a list</button>
 
   <div id="create-text-note-wrapper">
     <textarea id="create-text-note-textarea" rows="5"></textarea>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -12,12 +12,15 @@ async function sendMessage(message) {
 const $showOptionsButton = $("#show-options-button");
 const $clipScreenShotButton = $("#clip-screenshot-button");
 const $saveWholePageButton = $("#save-whole-page-button");
+const $saveTabsButton = $("#save-tabs-button");
 
 $showOptionsButton.on("click", () => browser.runtime.openOptionsPage());
 
 $clipScreenShotButton.on("click", () => sendMessage({name: 'save-screenshot'}));
 
 $saveWholePageButton.on("click", () => sendMessage({name: 'save-whole-page'}));
+
+$saveTabsButton.on("click", () => sendMessage({name: 'save-tabs'}));
 
 const $createTextNoteWrapper = $("#create-text-note-wrapper");
 const $textNote = $("#create-text-note-textarea");


### PR DESCRIPTION
First of all thank you for a great tool!

I was tired of slow, shady and bloated *Tab extensions in stores and wanted to organize everything in Trilium. This one makes my life easier when researching: keeps browser windows count sane, works super fast, won't blow up when there are hundreds of saved windows, benefits from all Trilium features, etc.

It reads current browser window's tabs urls and titles, throws them in a new note as a list of links and closes all these tabs.

It does not show a toast message after success like other user actions because the tab's context where the extension was activated is gone. But it won't close browser tabs and will show the failure message if there is an issue, so the result is pretty obvious to me. If this is a concern then a possible workaround is to show system notification, but this will require new permission in manifest.json.

Also I'm not sure if the button text "Save window's tabs as a list" is self-explanatory. I tried to make it short, so it doesn't mention that the tabs will be closed. There is a possibility that a new user cannot guess what happened.

Tested in Linux Chromium 88.0.4324.50 and Firefox 85.0.1, Trilium Notes 0.45.10 server.


Also I wrote a widget for Trilium which adds a button on top to open all links in labeled notes. To make it work, one has to:

1. Create a _Code_ type note anywhere in the document.
2. Change it's type to _JS frontend_.
3. Paste the code from below.
4. Add _#widget_ label in the _owned attribute_ widget.
5. Restart Trilium.

The button will only show up if the note has _#clipType=tabs_ (from web clipper) or _#links_ label and (obviously) links, though one can easily change it in the code.

```
const TPL = `<div style="contain: none; padding-bottom: 0.5rem">
    <button id="open-all-links" type="button" class="btn btn-sm"></button>
</div`;

class openLinksWidget extends api.TabAwareWidget {
    get position() { return 20; }

    get parentWidget() { return 'center-pane'; }

    doRender() {
        this.$widget = $(TPL);
        this.$openButton = this.$widget.find('#open-all-links');
        this.$links = []
        this.$openButton.on('click', async () => {
            this.$links.forEach(link => {
                window.open(link);
            });
        });
        
        return this.$widget;
    }

    async refreshWithNote(note) {
        if (note.type !== 'text' || (!note.hasLabel('links') && note.getLabelValue('clipType') !== 'tabs' ) ) { 
            this.toggleInt(false);
            return;
        }

        const {content} = await note.getNoteComplement();  
        this.$links = this.getExternalLinks(content);
        const linkCount = this.$links.length;
        
        if (linkCount < 1) {
            this.toggleInt(false);
            return;
        }
        
        this.$openButton.text(`Open all links (${linkCount})`);
        
        this.toggleInt(true);
    }
    
    getExternalLinks(content) {
        const re = /href="([^"]*)"/g;
        let match;
        let foundLinks = [];
        while (match = re.exec(content)) {
            foundLinks.push(match[1]);
        }
        
        return foundLinks
    }

    async entitiesReloadedEvent({loadResults}) {
        if (loadResults.isNoteContentReloaded(this.noteId)) {
            this.refresh();
        }
    }
}

module.exports = new openLinksWidget();
```
I haven't found a way to open links in a new browser window, so maybe you'll want to first open a new one manually before clicking the button. Also it only opens links in the system's default browser.