### PR TITLE
Add origin parameter

### DIFF
--- a/content.js
+++ b/content.js
@@ -259,7 +259,8 @@ async function prepareMessageResponse(message) {
 			title: pageTitle(),
 			content: container.innerHTML,
 			images: images,
-			pageUrl: getPageLocationOrigin() + location.pathname + location.search
+			pageUrl: getPageLocationOrigin() + location.pathname + location.search,
+			origin: getPageLocationOrigin(),
 		};
 
 	}
@@ -282,6 +283,7 @@ async function prepareMessageResponse(message) {
 			content: body.innerHTML,
 			images: images,
 			pageUrl: getPageLocationOrigin() + location.pathname + location.search,
+			origin: getPageLocationOrigin(),
 			clipType: 'page'
 		};
 	}


### PR DESCRIPTION
Requires: https://github.com/zadam/trilium/pull/2236

This allows for an "origin" attribute, so I can search all of my web saved notes by the domain. Example: 
![image](https://user-images.githubusercontent.com/69441971/137562116-7c61960f-c67b-49b7-b69c-6c60dc9d7cff.png)
So I would be able to search by this attribute to find any saved stories in this domain.