### PR TITLE
Save page without images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.project

--- a/background.js
+++ b/background.js
@@ -72,11 +72,13 @@ browser.contextMenus.create({
 	contexts: ["selection"]
 });
 
+/*
 browser.contextMenus.create({
 	id: "trilium-save-cropped-screenshot",
 	title: "Clip screenshot to Trilium",
 	contexts: ["page"]
 });
+*/
 
 browser.contextMenus.create({
 	id: "trilium-save-cropped-screenshot",
@@ -93,6 +95,12 @@ browser.contextMenus.create({
 browser.contextMenus.create({
 	id: "trilium-save-page",
 	title: "Save whole page to Trilium",
+	contexts: ["page"]
+});
+
+browser.contextMenus.create({
+	id: "trilium-save-page-without-image",
+	title: "Save whole page without image to Trilium",
 	contexts: ["page"]
 });
 
@@ -263,8 +271,8 @@ async function saveImage(srcUrl, pageUrl) {
 	toast("Image has been saved to Trilium.", resp.noteId);
 }
 
-async function saveWholePage() {
-	const payload = await sendMessageToActiveTab({name: 'trilium-save-page'});
+async function saveWholePage(withImage = true) {
+	const payload = await sendMessageToActiveTab({name: 'trilium-save-page', withImage: withImage});
 
 	await postProcessImages(payload);
 
@@ -380,6 +388,9 @@ browser.contextMenus.onClicked.addListener(async function(info, tab) {
 	else if (info.menuItemId === 'trilium-save-page') {
 		await saveWholePage();
 	}
+	else if (info.menuItemId === 'trilium-save-page-without-image') {
+		await saveWholePage(false);
+	}    
 	else {
 		console.log("Unrecognized menuItemId", info.menuItemId);
 	}
@@ -432,6 +443,9 @@ browser.runtime.onMessage.addListener(async request => {
 	else if (request.name === 'save-whole-page') {
 		return await saveWholePage();
 	}
+	else if (request.name === 'save-whole-page-without-image') {
+		return await saveWholePage(false);
+	}    
 	else if (request.name === 'save-link-with-note') {
 		return await saveLinkWithNote(request.title, request.content);
 	}

--- a/content.js
+++ b/content.js
@@ -208,6 +208,24 @@ function getImages(container) {
 	return images;
 }
 
+function removeImages(container) {
+    const images = [];
+
+    for (const img of container.getElementsByTagName('img')) {
+        if (!img.src) {
+            continue;
+        }
+
+        images.push(img);
+    }
+    
+    for (const img of images) {
+        img.remove();
+    }
+
+    return [];
+}
+
 function createLink(clickAction, text, color = "lightskyblue") {
 	const link = document.createElement('a');
 	link.href = "javascript:";
@@ -292,7 +310,7 @@ async function prepareMessageResponse(message) {
 
 		makeLinksAbsolute(body);
 
-		const images = getImages(body);
+		const images = message.withImage ? getImages(body) : removeImages(body);
 
 		return {
 			title: title,

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -21,6 +21,7 @@
   <button class="button full needs-connection" id="save-cropped-screenshot-button">Crop screen shot</button>
   <button class="button full needs-connection" id="save-whole-screenshot-button">Save whole screen shot</button>
   <button class="button full needs-connection" id="save-whole-page-button">Save whole page</button>
+  <button class="button full needs-connection" id="save-whole-page-without-image-button">Save whole page without image</button>
   <button class="button full needs-connection" id="save-link-with-note-button">Save link with a note</button>
   <button class="button full needs-connection" id="save-tabs-button">Save window's tabs as a list</button>
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -13,6 +13,7 @@ const $showOptionsButton = $("#show-options-button");
 const $saveCroppedScreenShotButton = $("#save-cropped-screenshot-button");
 const $saveWholeScreenShotButton = $("#save-whole-screenshot-button");
 const $saveWholePageButton = $("#save-whole-page-button");
+const $saveWholePageWithoutImageButton = $("#save-whole-page-without-image-button");
 const $saveTabsButton = $("#save-tabs-button");
 
 $showOptionsButton.on("click", () => browser.runtime.openOptionsPage());
@@ -30,6 +31,8 @@ $saveWholeScreenShotButton.on("click", () => {
 });
 
 $saveWholePageButton.on("click", () => sendMessage({name: 'save-whole-page'}));
+
+$saveWholePageWithoutImageButton.on("click", () => sendMessage({name: 'save-whole-page-without-image'}));
 
 $saveTabsButton.on("click", () => sendMessage({name: 'save-tabs'}));
 


### PR DESCRIPTION
Add a button/menu to save page without carrying over the images, useful when you only want the text, and it also saves space since images can be quite large.

Requested by https://github.com/zadam/trilium-web-clipper/issues/13