### PR TITLE
Keep the title when adding notes 

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -27,6 +27,10 @@
   <div id="save-link-with-note-wrapper">
     <textarea id="save-link-with-note-textarea" rows="5"></textarea>
 
+    <div>
+      <input type="checkbox" id="keep-title-checkbox" name="keep-title-checkbox" value="Bike">
+      <label for="keep-title-checkbox">Keep page title as note title</label><br>
+    </div>
     <div style="display: flex;">
       <button type="submit" class="button wide" id="save-button">Save</button>
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -35,6 +35,7 @@ $saveTabsButton.on("click", () => sendMessage({name: 'save-tabs'}));
 
 const $saveLinkWithNoteWrapper = $("#save-link-with-note-wrapper");
 const $textNote = $("#save-link-with-note-textarea");
+const $keepTitle = $("#keep-title-checkbox");
 
 $textNote.on('keypress', function (event) {
     if ((event.which === 10 || event.which === 13) && event.ctrlKey) {
@@ -65,6 +66,10 @@ async function saveLinkWithNote() {
     if (!textNoteVal) {
         title = '';
         content = '';
+    }
+    else if ($keepTitle[0].checked){
+        title = '';
+        content = textNoteVal;
     }
     else {
         const match = /^(.*?)([.?!]\s|\n)/.exec(textNoteVal);


### PR DESCRIPTION
Related to #51 
I edited the popup.html and popup.js to check whether to keep the title empty (which will be populated with the page title) or to use the default behavior