### PR TITLE
Check if the current page is already saved in trilium

### DIFF
--- a/background.js
+++ b/background.js
@@ -444,4 +444,8 @@ browser.runtime.onMessage.addListener(async request => {
 	else if (request.name === 'send-trilium-search-status') {
 		triliumServerFacade.sendTriliumSearchStatusToPopup();
 	}
+	else if (request.name === 'trigger-trilium-search-note-url') {
+		const activeTab = await getActiveTab();
+		triliumServerFacade.triggerSearchNoteByUrl(activeTab.url);
+	}
 });

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -10,6 +10,7 @@
 <body>
   <div style="display: flex; justify-content: space-between; vertical-align: middle;">
     <h3>Trilium Web Clipper</h3>
+    
 
     <div style="position: relative; top: 6px;">
       <button class="button" id="show-options-button">Options</button>
@@ -17,6 +18,7 @@
       <button class="button" id="show-help-button">Help</button>
     </div>
   </div>
+  <div id="already-visited"></div>
 
   <button class="button full needs-connection" id="save-cropped-screenshot-button">Crop screen shot</button>
   <button class="button full needs-connection" id="save-whole-screenshot-button">Save whole screen shot</button>
@@ -44,6 +46,7 @@
   <script src="../lib/cash.min.js"></script>
   <script src="popup.js"></script>
   <script src="../utils.js"></script>
+  <script src="../content.js"></script>
 </body>
 
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -108,6 +108,7 @@ function escapeHtml(string) {
 
 const $connectionStatus = $("#connection-status");
 const $needsConnection = $(".needs-connection");
+const $alreadyVisited = $("#already-visited");
 
 browser.runtime.onMessage.addListener(request => {
     if (request.name === 'trilium-search-status') {
@@ -140,11 +141,26 @@ browser.runtime.onMessage.addListener(request => {
         if (isConnected) {
             $needsConnection.removeAttr("disabled");
             $needsConnection.removeAttr("title");
+            browser.runtime.sendMessage({name: "trigger-trilium-search-note-url"});
         }
         else {
             $needsConnection.attr("disabled", "disabled");
             $needsConnection.attr("title", "This action can't be performed without active connection to Trilium.");
         }
+    }
+    else if (request.name == "trilium-previously-visited"){
+        const {searchNote} = request;
+        if (searchNote.status === 'found'){
+            const a = createLink({name: 'openNoteInTrilium', noteId: searchNote.noteId},
+            "Open in Trilium.")
+            noteFound = `Already visited website!`;
+            $alreadyVisited.html(noteFound);
+            $alreadyVisited[0].appendChild(a);
+        }else{
+            $alreadyVisited.html('');
+        }
+        
+
     }
 });
 

--- a/trilium_server_facade.js
+++ b/trilium_server_facade.js
@@ -23,6 +23,21 @@ class TriliumServerFacade {
 		}
 		catch (e) {} // nothing might be listening
 	}
+	async sendTriliumSearchNoteToPopup(){
+		try{
+			await browser.runtime.sendMessage({
+				name: "trilium-previously-visited",
+				searchNote: this.triliumSearchNote
+			})
+
+		}
+		catch (e) {} // nothing might be listening
+	}
+
+	setTriliumSearchNote(st){
+		this.triliumSearchNote = st;
+		this.sendTriliumSearchNoteToPopup();
+	}
 
 	setTriliumSearch(ts) {
 		this.triliumSearch = ts;
@@ -116,6 +131,18 @@ class TriliumServerFacade {
 		this.setTriliumSearch({ status: 'not-found' });
 	}
 
+	async triggerSearchNoteByUrl(noteUrl) {
+		const resp = await triliumServerFacade.callService('GET', 'notes-by-url/' + encodeURIComponent(noteUrl))
+		let newStatus = {
+			status: 'not-found',
+			noteId: null
+		}
+		if (resp && resp.noteId) {
+			newStatus.noteId = resp.noteId;
+			newStatus.status = 'found';
+		}
+		this.setTriliumSearchNote(newStatus);
+	}
 	async waitForTriliumSearch() {
 		return new Promise((res, rej) => {
 			const checkStatus = () => {


### PR DESCRIPTION
Related to #53   
I had to add an event listener that, after the web-clipper finds trilium (server or desktop application), will search if trilium has a note (under Inbox or `clipperInbox` ) with a `pageUrl` tag that is the same as the current page url. If the note is found an event is sent that will change the content of the ` <div id="already-visited"></div>` inside popup.html, otherwise the div is kept empty. 
This PR will work only after zadam/trilium#4075 is merged, since that PR exposes the endpoint to search a note by url