### PR TITLE
Capture location.hash into pageUrl attribute

### DIFF
--- a/content.js
+++ b/content.js
@@ -297,7 +297,7 @@ async function prepareMessageResponse(message) {
 			title: pageTitle(),
 			content: container.innerHTML,
 			images: images,
-			pageUrl: getPageLocationOrigin() + location.pathname + location.search
+			pageUrl: getPageLocationOrigin() + location.pathname + location.search + location.hash
 		};
 
 	}


### PR DESCRIPTION
Currently, when you clip a selection from a page with a named section, the pageUrl attribute is captured without named section. Consequently, when you click “This note was originally taken from” link in the captured note, you are navigated to the top of the page, and not to the named section.

Example of a page with named sections: 

https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/#ports

Currently, clipping loses `#ports` part. This PR preserves `#ports` in the resulting pageUrl attribute.